### PR TITLE
FIX: pip install git requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,4 @@ coverage
 coveralls
 nose
 # examples
--e git+git://github.com/scikit-signal/pytftb#egg=pytftb
+-e git+http://github.com/scikit-signal/pytftb#egg=pytftb


### PR DESCRIPTION
When installing the requirements I kept encountering the following error:

```
  Complete output from command git clone -q git://github.com/scikit-signal/pytftb /home/jrking/pyhht/src/pytftb:

  ----------------------------------------
Command "git clone -q git://github.com/scikit-signal/pytftb /home/jrking/pyhht/src/pytftb" failed with error code 128 in None
```

I'm running under Ubuntu 14.04, python 2.7.

This PR aims at fixing the issue.
