### PR TITLE
Fix sifting for fixed number of iterations

### DIFF
--- a/pyhht/emd.py
+++ b/pyhht/emd.py
@@ -263,7 +263,7 @@ class EmpiricalModeDecomposition(object):
         """
         # FIXME: This method needs a better name.
         if self.fixe:
-            stop_sift, moyenne = self.mean_and_amplitude(), 0
+            (moyenne, _, _, _), stop_sift = self.mean_and_amplitude(m), 0  # NOQA
         elif self.fixe_h:
             stop_count = 0
             try:
@@ -348,12 +348,7 @@ class EmpiricalModeDecomposition(object):
                 m = m - moyenne
 
                 # Computing mean and stopping criterion
-                if self.fixe:
-                    stop_sift, moyenne = self.stop_sifting_fixe()
-                elif self.fixe_h:
-                    stop_sift, moyenne, stop_count = self.stop_sifting_fixe_h()
-                else:
-                    stop_sift, moyenne = self.stop_sifting(m)
+                stop_sift, moyenne = self.stop_sifting(m)
 
                 self.nbit += 1
                 self.NbIt += 1
@@ -373,5 +368,6 @@ class EmpiricalModeDecomposition(object):
         if np.any(self.residue):
             self.imf.append(self.residue)
         return np.array(self.imf)
+
 
 EMD = EmpiricalModeDecomposition

--- a/pyhht/tests/test_emd.py
+++ b/pyhht/tests/test_emd.py
@@ -81,7 +81,18 @@ class TestEMD(unittest.TestCase):
         signal += np.random.normal(size=signal.shape)
         engine = EMD(signal, maxiter=200)
         engine.decompose()
-        self.assertEqual(engine.nbit, 200)
+        self.assertLessEqual(engine.nbit, 200)
+
+    def test_fixe(self):
+        """Check if the fixe parameter is respected."""
+        fpath = op.join(op.abspath(op.dirname(__file__)), "testdata",
+                        "gabor.mat")
+        signal = loadmat(fpath)['gabor'].ravel()
+        signal = resample(signal, signal.shape[0] * 100)
+        signal += np.random.normal(size=signal.shape)
+        engine = EMD(signal, fixe=100)
+        engine.decompose()
+        self.assertEqual(engine.nbit, 100)
 
     def test_residue(self):
         """Test the residue of the emd output."""
@@ -92,6 +103,7 @@ class TestEMD(unittest.TestCase):
         n_maxima = argrelmax(imfs[n_imfs - 1, :])[0].shape[0]
         n_minima = argrelmin(imfs[n_imfs - 1, :])[0].shape[0]
         self.assertTrue(max(n_maxima, n_minima) <= 2)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
The criterion to stop sifting based on fixe, fixe_h and maxiter is built
into a single function, `pyhht.EMD.stop_sifting`, there is no need to
evaluate this criterion in the decomposition loop separately. Also fix
a function call. Closes jaidevd/pyhht#31