### PR TITLE
Fix the doctest for index of orthogonality

### DIFF
--- a/pyhht/emd.py
+++ b/pyhht/emd.py
@@ -169,8 +169,8 @@ class EmpiricalModeDecomposition(object):
         >>> x = modes + t
         >>> decomposer = EMD(x)
         >>> imfs = decomposer.decompose()
-        >>> print(decomposer.io())
-        0.0170853675933
+        >>> print('%.3f' % decomposer.io())
+        0.017
         """
         imf = np.array(self.imf)
         dp = np.dot(imf, np.conj(imf).T)


### PR DESCRIPTION
Literally comparing floats within doctests may not always work, so
trunctate the float. Solution taken from:
https://stackoverflow.com/questions/2428618/how-to-test-floats-results-with-doctest